### PR TITLE
Fix issue where message is lost when logging hashes with multiple IO devices

### DIFF
--- a/lib/logtail/logger.rb
+++ b/lib/logtail/logger.rb
@@ -41,11 +41,13 @@ module Logtail
                          tags: tags)
           elsif logged_obj.is_a?(Hash)
             # Extract the tags
-            tags.push(logged_obj.delete(:tag)) if logged_obj.key?(:tag)
-            tags.concat(logged_obj.delete(:tags)) if logged_obj.key?(:tags)
+            tags.push(logged_obj[:tag]) if logged_obj.key?(:tag)
+            tags.concat(logged_obj[:tags]) if logged_obj.key?(:tags)
             tags.uniq!
 
-            message = logged_obj.delete(:message)
+            message = logged_obj[:message]
+
+            logged_obj = logged_obj.slice(*logged_obj.keys - [:message, :tag, :tags])
 
             LogEntry.new(level, time, progname, message, context_snapshot, logged_obj, tags: tags)
           else

--- a/spec/logtail/logger_spec.rb
+++ b/spec/logtail/logger_spec.rb
@@ -78,6 +78,16 @@ describe Logtail::Logger do
       expect(io.string).to eq("")
     end
 
+    it "should not lose message when logging hashes with multiple io devices" do
+      io1 = StringIO.new
+      io2 = StringIO.new
+      logger = Logtail::Logger.new(io1, io2)
+      message = {message: "payment rejected", payment_rejected: {customer_id: "abcde1234", amount: 100}}
+      logger.info(message)
+      expect(io1.string).to include("payment rejected")
+      expect(io2.string).to include("payment rejected")
+    end
+
     context "with the AugmentedFormatter" do
       before(:each) { logger.formatter = Logtail::Logger::AugmentedFormatter.new }
 


### PR DESCRIPTION
This fix was already submitted upstream at https://github.com/logtail/logtail-ruby/pull/14. Merging this here so we can use the fix without waiting for upstream.
